### PR TITLE
fix: cookieconsent

### DIFF
--- a/assets/js/cc_en.json
+++ b/assets/js/cc_en.json
@@ -4,7 +4,8 @@
         "description": "Consent Modal Description",
         "acceptAllBtn": "Accept all",
         "acceptNecessaryBtn": "Reject all",
-        "showPreferencesBtn": "Manage preferences"
+        "showPreferencesBtn": "Manage preferences",
+        "footer": "<a href=\"/privacy/\">Privacy Policy</a>\n<a href=\"/term/\">Terms and conditions</a>"        
     },
     "preferencesModal": {
         "title": "Cookie preferences",
@@ -51,7 +52,7 @@
             },
             {
                 "title": "More information",
-                "description": "For any queries in relation to our policy on cookies and your choices, please <a class=\"cc-link\" href=\"#yourdomain.com\">contact us</a>."
+                "description": "For any queries in relation to our policy on cookies and your choices, please <a class=\"cc-link\" href=\"/contact/\">contact us</a>."
             }
         ]
     }

--- a/assets/js/cc_fr.json
+++ b/assets/js/cc_fr.json
@@ -5,7 +5,7 @@
         "acceptAllBtn": "Tout accepter",
         "acceptNecessaryBtn": "Tout refuser",
         "showPreferencesBtn": "Gérer vos préférences",
-        "footer": "<a href=\"#/privacy/\">Politique de confidentialité</a>\n<a href=\"#/term/\">Termes et conditions</a>"
+        "footer": "<a href=\"/privacy/\">Politique de confidentialité</a>\n<a href=\"/term/\">Termes et conditions</a>"
     },
     "preferencesModal": {
         "title": "Gestion des préférences",
@@ -31,7 +31,7 @@
             },
             {
                 "title": "Information complémentaire",
-                "description": "Pour toute demande en lien avec les cookies, leur gestion et vos choix, n'hésitez pas à<a class=\"cc__link\" href=\"#/contact/\">me contacter</a>."
+                "description": "Pour toute demande en lien avec les cookies, leur gestion et vos choix, n'hésitez pas à<a class=\"cc__link\" href=\"/contact/\">me contacter</a>."
             }
         ]
     }

--- a/assets/js/cookieconsent-config.js
+++ b/assets/js/cookieconsent-config.js
@@ -17,7 +17,8 @@ CookieConsent.run({
     language: {
         default: 'fr',
         translations: {
-            fr: './assets/js/cc_fr.json'
+            fr: './assets/js/cc_fr.json',
+            en: './assets/js/cc_en.json'
             }
     }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,8 +96,10 @@ function sodosearch(done) {
 
 function cookieconsent(done) {
     pump([
-        src(['node_modules/vanilla-cookieconsent/dist/*.js',
-        'node_modules/vanilla-cookieconsent/dist/*.css']),
+        src([
+            'node_modules/vanilla-cookieconsent/dist/*.js',
+            'node_modules/vanilla-cookieconsent/dist/*.css'
+        ]),
         dest('assets/built/', {sourcemaps: '.'}),
         livereload()
     ], handleError(done));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "belline",
     "description": "A fork from headline Ghost theme",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "private": true,
     "engines": {
         "ghost": ">=5.0.0"


### PR DESCRIPTION
## rationale
- fix cookieconsent content
- (hopefully) fix github action theme deployment

## changes
### content
- fix modal windows URLs
- add english to translation list
### theme deployment
- `assets/built` contained neither `.js` nor `.css` files
- split file list in the pump funtion may solve this


